### PR TITLE
Remove obsolete future imports

### DIFF
--- a/magenta/common/__init__.py
+++ b/magenta/common/__init__.py
@@ -14,7 +14,6 @@
 
 """Imports objects into the top-level common namespace."""
 
-from __future__ import absolute_import
 
 from .beam_search import beam_search
 from .nade import Nade

--- a/magenta/common/nade.py
+++ b/magenta/common/nade.py
@@ -14,9 +14,6 @@
 
 """Implementation of a NADE (Neural Autoreressive Distribution Estimator)."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import math
 

--- a/magenta/contrib/training.py
+++ b/magenta/contrib/training.py
@@ -14,9 +14,6 @@
 
 # Forked from https://github.com/tensorflow/tensor2tensor/blob/master/tensor2tensor/utils/hparam.py  pylint: disable=line-too-long
 """Hyperparameter values."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import json
 import numbers

--- a/magenta/models/arbitrary_image_stylization/arbitrary_image_stylization_convert_tflite.py
+++ b/magenta/models/arbitrary_image_stylization/arbitrary_image_stylization_convert_tflite.py
@@ -14,9 +14,6 @@
 
 """Convert trained mobile arbitrary style transfer model to TF Lite."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import os
 import tempfile

--- a/magenta/models/coconet/coconet_evaluate.py
+++ b/magenta/models/coconet/coconet_evaluate.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 
 """Script to evaluate a dataset fold under a model."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import os
 

--- a/magenta/models/coconet/coconet_train.py
+++ b/magenta/models/coconet/coconet_train.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 
 """Train the model."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import os
 import time

--- a/magenta/models/coconet/lib_graph.py
+++ b/magenta/models/coconet/lib_graph.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 
 """Defines the graph for a convolutional net designed for music autofill."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import collections
 import os

--- a/magenta/models/coconet/lib_hparams.py
+++ b/magenta/models/coconet/lib_hparams.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 
 """Classes for defining hypermaters and model architectures."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import itertools as it
 import os

--- a/magenta/models/coconet/lib_logging.py
+++ b/magenta/models/coconet/lib_logging.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 
 """Utilities for structured logging of intermediate values during sampling."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import contextlib
 import os

--- a/magenta/models/coconet/lib_mask.py
+++ b/magenta/models/coconet/lib_mask.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 
 """Tools for masking out pianorolls in different ways, such as by instrument."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from magenta.models.coconet import lib_util
 import numpy as np

--- a/magenta/models/coconet/lib_saved_model.py
+++ b/magenta/models/coconet/lib_saved_model.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 
 """Utility for exporting and loading a Coconet SavedModel."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import tensorflow.compat.v1 as tf
 

--- a/magenta/models/coconet/lib_tfsampling.py
+++ b/magenta/models/coconet/lib_tfsampling.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 
 """Defines the graph for sampling from Coconet."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import time
 

--- a/magenta/models/coconet/lib_tfutil.py
+++ b/magenta/models/coconet/lib_tfutil.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 
 """Utilities that depend on Tensorflow."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import numpy as np
 import tensorflow.compat.v1 as tf

--- a/magenta/models/coconet/lib_util.py
+++ b/magenta/models/coconet/lib_util.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 
 """Utilities for context managing, data prep and sampling such as softmax."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import contextlib
 import datetime

--- a/magenta/models/drums_rnn/__init__.py
+++ b/magenta/models/drums_rnn/__init__.py
@@ -14,8 +14,5 @@
 
 """Imports Drums RNN model."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from .drums_rnn_model import DrumsRnnModel

--- a/magenta/models/gansynth/configs/mel_prog_hires.py
+++ b/magenta/models/gansynth/configs/mel_prog_hires.py
@@ -14,9 +14,6 @@
 
 """Config for training."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 # Hyperparameters
 hifreqres = True

--- a/magenta/models/gansynth/gansynth_train.py
+++ b/magenta/models/gansynth/gansynth_train.py
@@ -32,9 +32,6 @@ See https://arxiv.org/abs/1710.10196 for details about the model.
 See https://github.com/tkarras/progressive_growing_of_gans for the original
 theano implementation.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import importlib
 import json

--- a/magenta/models/gansynth/lib/data_helpers.py
+++ b/magenta/models/gansynth/lib/data_helpers.py
@@ -14,9 +14,6 @@
 
 """Data utility."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from magenta.models.gansynth.lib import datasets
 from magenta.models.gansynth.lib import train_util

--- a/magenta/models/gansynth/lib/datasets.py
+++ b/magenta/models/gansynth/lib/datasets.py
@@ -14,9 +14,6 @@
 
 """Module contains a registry of dataset classes."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import collections
 from magenta.models.gansynth.lib import spectral_ops

--- a/magenta/models/gansynth/lib/flags.py
+++ b/magenta/models/gansynth/lib/flags.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 
 """Flags utility object for handling hyperparameter state."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import base64
 import json

--- a/magenta/models/gansynth/lib/network_functions.py
+++ b/magenta/models/gansynth/lib/network_functions.py
@@ -15,9 +15,6 @@
 """Generator and discriminator functions.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from magenta.models.gansynth.lib import data_normalizer
 from magenta.models.gansynth.lib import layers

--- a/magenta/models/gansynth/lib/specgrams_helper.py
+++ b/magenta/models/gansynth/lib/specgrams_helper.py
@@ -18,9 +18,6 @@ Handles transformations between waveforms, stfts, spectrograms,
 mel-spectrograms, and instantaneous frequency (specgram).
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from magenta.models.gansynth.lib import spectral_ops
 import numpy as np

--- a/magenta/models/gansynth/lib/spectral_ops.py
+++ b/magenta/models/gansynth/lib/spectral_ops.py
@@ -18,9 +18,6 @@ Includes transforming linear to mel frequency scales and phase to instantaneous
 frequency.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import numpy as np
 import tensorflow.compat.v1 as tf

--- a/magenta/models/image_stylization/imagenet_data.py
+++ b/magenta/models/image_stylization/imagenet_data.py
@@ -24,9 +24,6 @@ Methods of ImagenetData class:
 This file was taken nearly verbatim from the tensorflow/models GitHub repo.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import os
 import sys

--- a/magenta/models/improv_rnn/__init__.py
+++ b/magenta/models/improv_rnn/__init__.py
@@ -14,8 +14,5 @@
 
 """Imports Improv RNN model."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from .improv_rnn_model import ImprovRnnModel

--- a/magenta/models/improv_rnn/improv_rnn_generate.py
+++ b/magenta/models/improv_rnn/improv_rnn_generate.py
@@ -14,9 +14,6 @@
 
 """Generate melodies from a trained checkpoint of an improv RNN model."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import ast
 import os

--- a/magenta/models/latent_transfer/interpolate_joint.py
+++ b/magenta/models/latent_transfer/interpolate_joint.py
@@ -19,9 +19,6 @@ images, as well as in other side of the model through paralleling,
 image-by-image transformation.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import importlib
 import os

--- a/magenta/models/latent_transfer/model_dataspace.py
+++ b/magenta/models/latent_transfer/model_dataspace.py
@@ -20,9 +20,6 @@ that explicitly model the data (x) in the latent space (z) and provide
 mechanism of encoding (x->z) and decoding (z->x).
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from magenta.models.latent_transfer.common import dataset_is_mnist_family
 import numpy as np

--- a/magenta/models/latent_transfer/model_joint.py
+++ b/magenta/models/latent_transfer/model_joint.py
@@ -19,9 +19,6 @@ of generative models that model the data. This file defines the joint model
 that models the transfer between latent spaces (z1, z2) of models on dataspace.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from magenta.models.latent_transfer import nn
 from six import iteritems

--- a/magenta/models/latent_transfer/sample_dataspace.py
+++ b/magenta/models/latent_transfer/sample_dataspace.py
@@ -19,9 +19,6 @@ This script provides sampling from VAE on dataspace trained using
 of model on dataspace.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import importlib
 import os

--- a/magenta/models/latent_transfer/train_joint.py
+++ b/magenta/models/latent_transfer/train_joint.py
@@ -20,9 +20,6 @@ This script train the joint model defined in `model_joint.py` that transfers
 between latent space of generative models that model the data.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from functools import partial
 import importlib

--- a/magenta/models/melody_rnn/__init__.py
+++ b/magenta/models/melody_rnn/__init__.py
@@ -14,8 +14,5 @@
 
 """Imports Melody RNN model."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from .melody_rnn_model import MelodyRnnModel

--- a/magenta/models/music_vae/data_hierarchical_test.py
+++ b/magenta/models/music_vae/data_hierarchical_test.py
@@ -14,9 +14,6 @@
 
 """Tests for hierarchical data converters."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import copy
 

--- a/magenta/models/music_vae/data_test.py
+++ b/magenta/models/music_vae/data_test.py
@@ -14,9 +14,6 @@
 
 """Tests for MusicVAE data library."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import functools
 from unittest import mock

--- a/magenta/models/music_vae/music_vae_generate.py
+++ b/magenta/models/music_vae/music_vae_generate.py
@@ -16,9 +16,6 @@
 
 # TODO(adarob): Add support for models with conditioning.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import os
 import sys

--- a/magenta/models/nsynth/reader.py
+++ b/magenta/models/nsynth/reader.py
@@ -14,9 +14,6 @@
 
 """Module to load the Dataset."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from magenta.models.nsynth import utils
 import numpy as np

--- a/magenta/models/nsynth/wavenet/masked.py
+++ b/magenta/models/nsynth/wavenet/masked.py
@@ -14,9 +14,6 @@
 
 """A library of functions that help with causal masking."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import tensorflow.compat.v1 as tf
 

--- a/magenta/models/onsets_frames_transcription/__init__.py
+++ b/magenta/models/onsets_frames_transcription/__init__.py
@@ -14,6 +14,3 @@
 
 """Imports Onsets and Frames model."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function

--- a/magenta/models/onsets_frames_transcription/audio_label_data_utils.py
+++ b/magenta/models/onsets_frames_transcription/audio_label_data_utils.py
@@ -14,9 +14,6 @@
 
 r"""Utilities for managing wav files and labels for transcription."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import bisect
 import math

--- a/magenta/models/onsets_frames_transcription/audio_label_data_utils_test.py
+++ b/magenta/models/onsets_frames_transcription/audio_label_data_utils_test.py
@@ -14,9 +14,6 @@
 
 """Test for audio_label_data_utils."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from magenta.models.onsets_frames_transcription import audio_label_data_utils
 

--- a/magenta/models/onsets_frames_transcription/audio_transform.py
+++ b/magenta/models/onsets_frames_transcription/audio_transform.py
@@ -14,9 +14,6 @@
 
 """SoX-based audio transform functions for the purpose of data augmentation."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import math
 import random

--- a/magenta/models/onsets_frames_transcription/configs.py
+++ b/magenta/models/onsets_frames_transcription/configs.py
@@ -14,9 +14,6 @@
 
 """Configurations for transcription models."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import collections
 

--- a/magenta/models/onsets_frames_transcription/constants.py
+++ b/magenta/models/onsets_frames_transcription/constants.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 
 """Defines shared constants used in transcription models."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import librosa
 

--- a/magenta/models/onsets_frames_transcription/infer_util.py
+++ b/magenta/models/onsets_frames_transcription/infer_util.py
@@ -14,9 +14,6 @@
 
 """Utilities for inference."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import collections
 

--- a/magenta/models/onsets_frames_transcription/infer_util_test.py
+++ b/magenta/models/onsets_frames_transcription/infer_util_test.py
@@ -14,9 +14,6 @@
 
 """Tests for metrics."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from magenta.models.onsets_frames_transcription import infer_util
 

--- a/magenta/models/onsets_frames_transcription/metrics.py
+++ b/magenta/models/onsets_frames_transcription/metrics.py
@@ -14,9 +14,6 @@
 
 """Transcription metrics calculations."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import collections
 import functools

--- a/magenta/models/onsets_frames_transcription/model.py
+++ b/magenta/models/onsets_frames_transcription/model.py
@@ -14,9 +14,6 @@
 
 """Onset-focused model for piano transcription."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import functools
 

--- a/magenta/models/onsets_frames_transcription/model_tpu.py
+++ b/magenta/models/onsets_frames_transcription/model_tpu.py
@@ -14,9 +14,6 @@
 
 """Onset-focused model for piano and drum transcription, TPU compatible."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from magenta.contrib import rnn as contrib_rnn
 from magenta.contrib import training as contrib_training

--- a/magenta/models/onsets_frames_transcription/onsets_frames_transcription_create_dataset.py
+++ b/magenta/models/onsets_frames_transcription/onsets_frames_transcription_create_dataset.py
@@ -14,9 +14,6 @@
 
 r"""Beam job for creating transcription dataset."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from magenta.models.onsets_frames_transcription import configs
 from magenta.models.onsets_frames_transcription import create_dataset

--- a/magenta/models/onsets_frames_transcription/onsets_frames_transcription_infer.py
+++ b/magenta/models/onsets_frames_transcription/onsets_frames_transcription_infer.py
@@ -14,9 +14,6 @@
 
 """Run inference for onset conditioned model."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from magenta.models.onsets_frames_transcription import configs
 from magenta.models.onsets_frames_transcription import data

--- a/magenta/models/onsets_frames_transcription/onsets_frames_transcription_spectrogram_json.py
+++ b/magenta/models/onsets_frames_transcription/onsets_frames_transcription_spectrogram_json.py
@@ -17,9 +17,6 @@
 Usage: onsets_frames_transcription_specjson file1.wav [file2.wav file3.wav]
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import json
 

--- a/magenta/models/onsets_frames_transcription/onsets_frames_transcription_train.py
+++ b/magenta/models/onsets_frames_transcription/onsets_frames_transcription_train.py
@@ -14,9 +14,6 @@
 
 r"""Train Onsets and Frames piano transcription model."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import functools
 import os

--- a/magenta/models/onsets_frames_transcription/onsets_frames_transcription_transcribe.py
+++ b/magenta/models/onsets_frames_transcription/onsets_frames_transcription_transcribe.py
@@ -14,9 +14,6 @@
 
 """Transcribe a recording of piano audio."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import os
 

--- a/magenta/models/performance_rnn/__init__.py
+++ b/magenta/models/performance_rnn/__init__.py
@@ -14,8 +14,5 @@
 
 """Imports Performance RNN model."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from .performance_model import PerformanceRnnModel

--- a/magenta/models/performance_rnn/performance_sequence_generator.py
+++ b/magenta/models/performance_rnn/performance_sequence_generator.py
@@ -14,7 +14,6 @@
 
 """Performance RNN generation code as a SequenceGenerator interface."""
 
-from __future__ import division
 
 import ast
 import functools

--- a/magenta/models/piano_genie/configs.py
+++ b/magenta/models/piano_genie/configs.py
@@ -14,9 +14,6 @@
 
 """Hyperparameter configurations for Piano Genie."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 import six
 
 

--- a/magenta/models/piano_genie/gold.py
+++ b/magenta/models/piano_genie/gold.py
@@ -14,9 +14,6 @@
 
 """Gold standard musical sequences."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 # pylint:disable=g-line-too-long,line-too-long
 _MARYLMB = (

--- a/magenta/models/piano_genie/loader.py
+++ b/magenta/models/piano_genie/loader.py
@@ -14,9 +14,6 @@
 
 """Loads music data from TFRecords."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import random
 

--- a/magenta/models/piano_genie/util.py
+++ b/magenta/models/piano_genie/util.py
@@ -14,9 +14,6 @@
 
 """Utility functions for Piano Genie."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import numpy as np
 import tensorflow.compat.v1 as tf

--- a/magenta/models/pianoroll_rnn_nade/__init__.py
+++ b/magenta/models/pianoroll_rnn_nade/__init__.py
@@ -14,8 +14,5 @@
 
 """Imports Pianoroll RNN-NADE model."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from .pianoroll_rnn_nade_model import PianorollRnnNadeModel

--- a/magenta/models/polyphony_rnn/__init__.py
+++ b/magenta/models/polyphony_rnn/__init__.py
@@ -14,8 +14,5 @@
 
 """Imports Polyphony RNN model."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from .polyphony_model import PolyphonyRnnModel

--- a/magenta/models/polyphony_rnn/polyphony_encoder_decoder.py
+++ b/magenta/models/polyphony_rnn/polyphony_encoder_decoder.py
@@ -14,7 +14,6 @@
 
 """Classes for converting between polyphonic input and model input/output."""
 
-from __future__ import division
 
 from magenta.models.polyphony_rnn import polyphony_lib
 from magenta.models.polyphony_rnn.polyphony_lib import PolyphonicEvent

--- a/magenta/models/polyphony_rnn/polyphony_lib.py
+++ b/magenta/models/polyphony_rnn/polyphony_lib.py
@@ -14,7 +14,6 @@
 
 """Utility functions for working with polyphonic sequences."""
 
-from __future__ import division
 
 import collections
 import copy

--- a/magenta/models/rl_tuner/rl_tuner.py
+++ b/magenta/models/rl_tuner/rl_tuner.py
@@ -24,9 +24,6 @@ algorithm can be switched using the 'algorithm' hyperparameter.
 For more information, please consult the README.md file in this directory.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import collections
 import os

--- a/magenta/models/rl_tuner/rl_tuner_ops.py
+++ b/magenta/models/rl_tuner/rl_tuner_ops.py
@@ -14,9 +14,6 @@
 
 """Helper functions to support the RLTuner and NoteRNNLoader classes."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import os
 import random

--- a/magenta/models/score2perf/modalities.py
+++ b/magenta/models/score2perf/modalities.py
@@ -14,9 +14,6 @@
 
 """Modality transformations used by Magenta and not in core Tensor2Tensor."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from tensor2tensor.layers import common_layers
 import tensorflow.compat.v1 as tf

--- a/magenta/models/score2perf/music_encoders.py
+++ b/magenta/models/score2perf/music_encoders.py
@@ -14,9 +14,6 @@
 
 """Tensor2Tensor encoders for music."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import tempfile
 

--- a/magenta/models/score2perf/score2perf.py
+++ b/magenta/models/score2perf/score2perf.py
@@ -14,9 +14,6 @@
 
 """Performance generation from score in Tensor2Tensor."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import functools
 import itertools

--- a/magenta/models/score2perf/score2perf_hparams.py
+++ b/magenta/models/score2perf/score2perf_hparams.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 
 """Hparams for symbolic music modeling tasks."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from tensor2tensor.models import transformer
 from tensor2tensor.utils import registry

--- a/magenta/models/svg_vae/glyphazzn.py
+++ b/magenta/models/svg_vae/glyphazzn.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 
 """Defines the GlyphAzznProblem."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import os
 

--- a/magenta/models/svg_vae/image_vae.py
+++ b/magenta/models/svg_vae/image_vae.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 
 """Defines the ImageVAE model."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import collections
 

--- a/magenta/models/svg_vae/svg_decoder_loss.py
+++ b/magenta/models/svg_vae/svg_decoder_loss.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 
 """Defines SVG decoder loss."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import numpy as np
 

--- a/magenta/pipelines/dag_pipeline.py
+++ b/magenta/pipelines/dag_pipeline.py
@@ -30,9 +30,6 @@ type signature: Something that can be returned from Pipeline's `output_type`
     or `input_type`. A python class, or dictionary mapping names to classes.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import itertools
 

--- a/magenta/pipelines/pipeline.py
+++ b/magenta/pipelines/pipeline.py
@@ -14,9 +14,6 @@
 
 """For running data processing pipelines."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import abc
 import inspect

--- a/magenta/video/next_frame_prediction_pix2pix/join_pairs.py
+++ b/magenta/video/next_frame_prediction_pix2pix/join_pairs.py
@@ -17,7 +17,6 @@ The goal is to create pairs with a frame to the next frame
 it can match a real frame to a recursively generated frame
 for instance (r0001.png) with a real frame (f0002.png)
 """
-from __future__ import print_function
 
 import argparse
 import glob

--- a/magenta/video/tools/convert2jpg.py
+++ b/magenta/video/tools/convert2jpg.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 """convert all files in a folder to jpg."""
-from __future__ import print_function
 
 import argparse
 import glob

--- a/magenta/video/tools/extract_frames.py
+++ b/magenta/video/tools/extract_frames.py
@@ -16,9 +16,6 @@
 
 Files are prefixed by a f followed by the frame number.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import argparse
 import glob

--- a/magenta/video/tools/random_pick.py
+++ b/magenta/video/tools/random_pick.py
@@ -16,7 +16,6 @@
 
 Only useful if used with the --limit flag unless it will copy the whole folder
 """
-from __future__ import print_function
 
 import argparse
 import glob


### PR DESCRIPTION
## Summary
- remove legacy __future__ imports across the codebase

## Testing
- `pytest --ignore=magenta/models/score2perf` *(fails: ModuleNotFoundError: No module named 'absl')*

------
https://chatgpt.com/codex/tasks/task_e_68405b6c0230833092a8ec35eebd96c9