### PR TITLE
Update build workflow to Python 3.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,11 +10,12 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.8'
+        python-version: '3.11'
     - name: Install dependencies
       run: |
         sudo apt update
-        sudo apt-get -y install ffmpeg build-essential libasound2-dev libjack-dev sox
+        sudo apt-get -y install ffmpeg build-essential libasound2-dev libjack-dev sox python3-dev
+        python -m pip install --upgrade pip
         pip install -e .[test]
     - name: Test with pytest
       run: pytest --ignore=magenta/models/score2perf


### PR DESCRIPTION
## Summary
- use Python 3.11 in CI
- install python3-dev and upgrade pip before installing deps

## Testing
- `pip install -e .[test]` *(fails: conflicting dependencies)*
- `pytest --maxfail=1 --ignore=magenta/models/score2perf` *(fails: ModuleNotFoundError: No module named 'absl')*

------
https://chatgpt.com/codex/tasks/task_e_6840696d07e08330b0b2bb981d9ee588