### PR TITLE
Update protobuf requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
   "tensorflow-probability==0.17.0",
   "tf_slim==1.1.0",
   "wheel==0.37.1",
-  "protobuf==3.20.0",
+  "protobuf>=3.20.3,<5",
   "pychord",
 ]
 


### PR DESCRIPTION
## Summary
- relax `protobuf` pin in `pyproject.toml`
- `pip install . --no-deps --force-reinstall` on Python 3.11 succeeded

## Testing
- `pip install . --no-deps --force-reinstall -v > /tmp/pip_install.log`


------
https://chatgpt.com/codex/tasks/task_e_68407da4f9c88330b5bfb2b0b7397052