### PR TITLE
Bump Magenta version to 2.1.5

### DIFF
--- a/magenta/version.py
+++ b/magenta/version.py
@@ -18,4 +18,4 @@ Stored in a separate file so that setup.py can reference the version without
 pulling in all the dependencies in __init__.py.
 """
 
-__version__ = '2.1.4'
+__version__ = '2.1.5'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "magenta"
-version = "2.1.4"
+version = "2.1.5"
 description = "Use machine learning to create art and music"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- update version constants for release 2.1.5

## Testing
- `pip install -e . --no-deps`
- `pytest -k version -q` *(fails: ModuleNotFoundError: No module named 'absl')*

------
https://chatgpt.com/codex/tasks/task_e_68408685a97883308673362c2ae54785