### PR TITLE
Pin TensorFlow 2.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
 # Magenta for Colab
 
 Work in progress to update Magenta to run on current Colab (Python 3.11)
+
+## Installation
+
+Magenta currently supports **Python 3.11**. Install it with pip and ensure TensorFlow 2.14 is selected:
+
+```bash
+pip install magenta "tensorflow>=2.14,<2.15" "keras<3"
+```
+
+TensorFlow 2.15 and newer releases are not yet supported, and Python versions newer than 3.11 are incompatible.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "magenta"
 version = "2.1.4"
 description = "Use machine learning to create art and music"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.11,<3.12"
 license = {text = "Apache-2.0"}
 authors = [
   {name = "Google Inc.", email = "magenta-discuss@gmail.com"}
@@ -46,7 +46,8 @@ dependencies = [
   "six>=1.17.0",
   "sk-video>=1.1.10",
   "sox>=1.5.0",
-  "tensorflow>=2.13",
+  "tensorflow>=2.14,<2.15",
+  "keras<3",
   "tensorflow-datasets>=4.9",
   "tensorflow-probability>=0.21",
   "tf_slim>=1.1.0",


### PR DESCRIPTION
## Summary
- restrict TensorFlow to `<2.15`
- add keras requirement
- show TensorFlow pin in README install instructions
- clarify that Python 3.11 is required

## Testing
- `pytest -q` *(fails: TypeError: Unable to convert function return value to a Python type!)*

------
https://chatgpt.com/codex/tasks/task_e_6840a82aa2888330a13f8466d5b0e724