### PR TITLE
Fix packaging version string

### DIFF
--- a/magenta/version.py
+++ b/magenta/version.py
@@ -18,4 +18,4 @@ Stored in a separate file so that setup.py can reference the version without
 pulling in all the dependencies in __init__.py.
 """
 
-__version__ = '2.1.4'
+__version__ = '2.1.4+yolo2'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "magenta"
-version = "2.1.4-yolo2"
+version = "2.1.4+yolo2"
 description = "Use machine learning to create art and music"
 readme = "README.md"
 requires-python = ">=3.11,<3.12"


### PR DESCRIPTION
## Summary
- use valid version format in `pyproject.toml`
- keep the same value in `magenta/version.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tensorflow')*

------
https://chatgpt.com/codex/tasks/task_e_6840b74be8b48330b1ce02dd06f7aff8