### PR TITLE
Refactor for keras 3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Work in progress to update Magenta to run on current Colab (Python 3.11)
 Magenta currently supports **Python 3.11**. Install it with pip and ensure TensorFlow 2.14 is selected:
 
 ```bash
-pip install magenta "tensorflow>=2.14,<2.15" "keras<3"
+pip install magenta "tensorflow>=2.14,<2.15" "keras>=3.5"
 ```
 
 TensorFlow 2.15 and newer releases are not yet supported, and Python versions newer than 3.11 are incompatible.

--- a/magenta/contrib/rnn.py
+++ b/magenta/contrib/rnn.py
@@ -614,7 +614,7 @@ class LayerRNNCell(rnn_cell.RNNCell):
     # Bypass RNNCell's variable capturing semantics for LayerRNNCell.
     # Instead, it is up to subclasses to provide a proper build
     # method.  See the class docstring for more details.
-    return tf.layers.Layer.__call__(
+    return tf.keras.layers.Layer.__call__(
         self, inputs, state, scope=scope, *args, **kwargs)
 
 
@@ -731,7 +731,7 @@ class LSTMBlockCell(LayerRNNCell):
         "scope": "lstm_cell"
     }
     # Inputs must be 2-dimensional.
-    self.input_spec = tf.layers.InputSpec(ndim=2)
+    self.input_spec = tf.keras.layers.InputSpec(ndim=2)
 
   @property
   def state_size(self):

--- a/magenta/contrib/seq2seq.py
+++ b/magenta/contrib/seq2seq.py
@@ -157,7 +157,7 @@ class Decoder(object, metaclass=abc.ABCMeta):
     return False
 
 
-class BaseDecoder(tf.layers.Layer):
+class BaseDecoder(tf.keras.layers.Layer):
   """An RNN Decoder that is based on a Keras layer.
 
   Concepts used by this interface:
@@ -1002,7 +1002,7 @@ class BasicDecoder(Decoder):
     if not isinstance(helper, Helper):
       raise TypeError("helper must be a Helper, received: %s" % type(helper))
     if (output_layer is not None and
-        not isinstance(output_layer, tf.layers.Layer)):
+        not isinstance(output_layer, tf.keras.layers.Layer)):
       raise TypeError("output_layer must be a Layer, received: %s" %
                       type(output_layer))
     self._cell = cell

--- a/magenta/contrib/seq2seq_test.py
+++ b/magenta/contrib/seq2seq_test.py
@@ -182,7 +182,7 @@ class BasicDecoderTest(tf.test.TestCase):
       helper = seq2seq.TrainingHelper(
           inputs, sequence_length, time_major=False)
       if use_output_layer:
-        output_layer = tf.layers.Dense(output_layer_depth, use_bias=False)
+        output_layer = tf.keras.layers.Dense(output_layer_depth, use_bias=False)
         expected_output_depth = output_layer_depth
       else:
         output_layer = None

--- a/magenta/models/coconet/lib_graph.py
+++ b/magenta/models/coconet/lib_graph.py
@@ -277,7 +277,7 @@ class CoconetGraph(object):
       tf.logging.info('dilation_rate %r', dilation_rate)
       if num_splits > 1:
         num_outputs = None
-      conv = tf.layers.separable_conv2d(
+      conv = tf.keras.layers.separable_conv2d(
           x,
           num_outputs,
           filter_shape[:2],
@@ -293,7 +293,7 @@ class CoconetGraph(object):
         print(len(splits), splits[0].shape)
         # TODO(annahuang): support non equal splits.
         pointwise_splits = [
-            tf.layers.dense(splits[i], filter_shape[3]/num_splits,
+            tf.keras.layers.dense(splits[i], filter_shape[3]/num_splits,
                             name='split_%d_%d' % (layer_idx, i))
             for i in range(num_splits)]
         conv = tf.concat((pointwise_splits), axis=-1)

--- a/magenta/models/gansynth/lib/layers.py
+++ b/magenta/models/gansynth/lib/layers.py
@@ -247,7 +247,7 @@ def custom_conv2d(x,
                   reuse=None):
   """Custom conv2d layer.
 
-  In comparison with tf.layers.conv2d this implementation use the He initializer
+  In comparison with tf.keras.layers.conv2d this implementation use the He initializer
   to initialize convolutional kernel and the weight scaling trick (if
   `use_weight_scaling` is True) to equalize learning rates. See
   https://arxiv.org/abs/1710.10196 for more details.
@@ -273,7 +273,7 @@ def custom_conv2d(x,
   kernel_size = list(kernel_size)
 
   def _apply_kernel(kernel_shape, kernel_initializer):
-    return tf.layers.conv2d(
+    return tf.keras.layers.conv2d(
         x,
         filters=filters,
         kernel_size=kernel_shape[0:2],
@@ -301,7 +301,7 @@ def custom_dense(x,
                  reuse=None):
   """Custom dense layer.
 
-  In comparison with tf.layers.dense This implementation use the He
+  In comparison with tf.keras.layers.dense This implementation use the He
   initializer to initialize weights and the weight scaling trick
   (if `use_weight_scaling` is True) to equalize learning rates. See
   https://arxiv.org/abs/1710.10196 for more details.
@@ -319,10 +319,10 @@ def custom_dense(x,
   Returns:
     A `Tensor` where the last dimension has size `units`.
   """
-  x = tf.layers.flatten(x)
+  x = tf.keras.layers.flatten(x)
 
   def _apply_kernel(kernel_shape, kernel_initializer):
-    return tf.layers.dense(
+    return tf.keras.layers.dense(
         x,
         kernel_shape[1],
         use_bias=False,

--- a/magenta/models/gansynth/lib/network_functions.py
+++ b/magenta/models/gansynth/lib/network_functions.py
@@ -69,7 +69,7 @@ def discriminator_fn_specgram(images, **kwargs):
       kernel_size=kwargs['kernel_size'],
       simple_arch=kwargs['simple_arch'])
   with tf.variable_scope('discriminator_cond'):
-    x = tf.layers.flatten(end_points['last_conv'])
+    x = tf.keras.layers.flatten(end_points['last_conv'])
     end_points['classification_logits'] = layers.custom_dense(
         x=x, units=kwargs['num_tokens'], scope='classification_logits')
   return logits, end_points

--- a/magenta/models/gansynth/lib/networks.py
+++ b/magenta/models/gansynth/lib/networks.py
@@ -354,7 +354,7 @@ def generator(z,
     with tf.variable_scope(block_name(1)):
       if simple_arch:
         x_shape = tf.shape(x)
-        x = tf.layers.dense(x, start_h*start_w*num_filters_fn(1),
+        x = tf.keras.layers.dense(x, start_h*start_w*num_filters_fn(1),
                             kernel_initializer=he_init)
         x = tf.nn.relu(x)
         x = tf.reshape(x, [x_shape[0], start_h, start_w, num_filters_fn(1)])
@@ -378,7 +378,7 @@ def generator(z,
     for block_id in range(2, num_blocks + 1):
       with tf.variable_scope(block_name(block_id)):
         if simple_arch:
-          x = tf.layers.conv2d_transpose(
+          x = tf.keras.layers.conv2d_transpose(
               x,
               num_filters_fn(block_id),
               kernel_size=kernel_size,
@@ -397,7 +397,7 @@ def generator(z,
       with tf.variable_scope(block_name(block_id)):
         if simple_arch:
           lod = lods[block_id - 1]
-          lod = tf.layers.conv2d(
+          lod = tf.keras.layers.conv2d(
               lod,
               colors,
               kernel_size=1,
@@ -491,7 +491,7 @@ def discriminator(x,
         lod = resolution_schedule.downscale(x0, scale)
         end_points['downscaled_rgb_{}'.format(block_id)] = lod
         if simple_arch:
-          lod = tf.layers.conv2d(
+          lod = tf.keras.layers.conv2d(
               lod,
               num_filters_fn(block_id),
               kernel_size=1,
@@ -511,7 +511,7 @@ def discriminator(x,
     for block_id in range(num_blocks, 1, -1):
       with tf.variable_scope(block_name(block_id)):
         if simple_arch:
-          x = tf.layers.conv2d(
+          x = tf.keras.layers.conv2d(
               x,
               num_filters_fn(block_id-1),
               strides=strides,
@@ -531,7 +531,7 @@ def discriminator(x,
       x = layers.scalar_concat(x, layers.minibatch_mean_stddev(x))
       if simple_arch:
         x = tf.reshape(x, [tf.shape(x)[0], -1])  # flatten
-        x = tf.layers.dense(x, num_filters_fn(0), name='last_conv',
+        x = tf.keras.layers.dense(x, num_filters_fn(0), name='last_conv',
                             kernel_initializer=he_init)
         x = tf.reshape(x, [tf.shape(x)[0], 1, 1, num_filters_fn(0)])
         x = tf.nn.relu(x)
@@ -541,7 +541,7 @@ def discriminator(x,
                     num_filters_fn(0), 'VALID')
       end_points['last_conv'] = x
       if simple_arch:
-        logits = tf.layers.dense(x, 1, name='logits',
+        logits = tf.keras.layers.dense(x, 1, name='logits',
                                  kernel_initializer=he_init)
       else:
         logits = layers.custom_dense(x=x, units=1, scope='logits')

--- a/magenta/models/music_vae/base_model.py
+++ b/magenta/models/music_vae/base_model.py
@@ -192,12 +192,12 @@ class MusicVAE(object):
       sequence = tf.concat([sequence, control_sequence], axis=-1)
     encoder_output = self.encoder.encode(sequence, sequence_length)
 
-    mu = tf.layers.dense(
+    mu = tf.keras.layers.dense(
         encoder_output,
         z_size,
         name='encoder/mu',
         kernel_initializer=tf.random_normal_initializer(stddev=0.001))
-    sigma = tf.layers.dense(
+    sigma = tf.keras.layers.dense(
         encoder_output,
         z_size,
         activation=tf.nn.softplus,

--- a/magenta/models/music_vae/lstm_models.py
+++ b/magenta/models/music_vae/lstm_models.py
@@ -226,7 +226,7 @@ class BaseLstmDecoder(base_model.BaseDecoder):
     self._sampling_probability = lstm_utils.get_sampling_probability(
         hparams, is_training)
     self._output_depth = output_depth
-    self._output_layer = tf.layers.Dense(
+    self._output_layer = tf.keras.layers.Dense(
         output_depth, name='output_projection')
     self._dec_cell = lstm_utils.rnn_cell(
         hparams.dec_rnn_size, hparams.dropout_keep_prob,
@@ -782,7 +782,7 @@ class MultiLabelRnnNadeDecoder(BaseLstmDecoder):
     super(MultiLabelRnnNadeDecoder, self).build(
         hparams, output_depth, is_training)
     # Overwrite output layer for NADE parameterization.
-    self._output_layer = tf.layers.Dense(
+    self._output_layer = tf.keras.layers.Dense(
         self._nade.num_hidden + output_depth, name='output_projection')
 
   def _flat_reconstruction_loss(self, flat_x_target, flat_rnn_output):

--- a/magenta/models/music_vae/lstm_utils.py
+++ b/magenta/models/music_vae/lstm_utils.py
@@ -91,7 +91,7 @@ def initial_cell_state_from_embedding(cell, z, name=None):
   return tf.nest.pack_sequence_as(
       cell.zero_state(batch_size=z.shape[0], dtype=tf.float32),
       tf.split(
-          tf.layers.dense(
+          tf.keras.layers.dense(
               z,
               sum(flat_state_sizes),
               activation=tf.tanh,

--- a/magenta/models/piano_genie/model.py
+++ b/magenta/models/piano_genie/model.py
@@ -32,7 +32,7 @@ def simple_lstm_encoder(features,
   x = features
 
   with tf.variable_scope("rnn_input"):
-    x = tf.layers.dense(x, rnn_nunits)
+    x = tf.keras.layers.dense(x, rnn_nunits)
 
   if rnn_celltype == "lstm":
     celltype = contrib_rnn.LSTMBlockCell
@@ -74,7 +74,7 @@ def simple_lstm_decoder(features,
   x = features
 
   with tf.variable_scope("rnn_input"):
-    x = tf.layers.dense(x, rnn_nunits)
+    x = tf.keras.layers.dense(x, rnn_nunits)
 
   if rnn_celltype == "lstm":
     celltype = contrib_rnn.LSTMBlockCell
@@ -185,7 +185,7 @@ def build_genie_model(feat_dict,
   # Step embeddings (single vector per timestep)
   if cfg.stp_emb_unconstrained:
     with tf.variable_scope("stp_emb_unconstrained"):
-      stp_emb_unconstrained = tf.layers.dense(
+      stp_emb_unconstrained = tf.keras.layers.dense(
           enc_stp, cfg.stp_emb_unconstrained_embedding_dim)
 
     out_dict["stp_emb_unconstrained"] = stp_emb_unconstrained
@@ -197,7 +197,7 @@ def build_genie_model(feat_dict,
     with tf.variable_scope("stp_emb_vq"):
       with tf.variable_scope("pre_vq"):
         # pre_vq_encoding is tf.float32 of [batch_size, seq_len, embedding_dim]
-        pre_vq_encoding = tf.layers.dense(enc_stp, cfg.stp_emb_vq_embedding_dim)
+        pre_vq_encoding = tf.keras.layers.dense(enc_stp, cfg.stp_emb_vq_embedding_dim)
 
       with tf.variable_scope("quantizer"):
         assert stp_varlen_mask is None
@@ -230,7 +230,7 @@ def build_genie_model(feat_dict,
     with tf.variable_scope("stp_emb_iq"):
       with tf.variable_scope("pre_iq"):
         # pre_iq_encoding is tf.float32 of [batch_size, seq_len]
-        pre_iq_encoding = tf.layers.dense(enc_stp, 1)[:, :, 0]
+        pre_iq_encoding = tf.keras.layers.dense(enc_stp, 1)[:, :, 0]
 
       def iqst(x, n):
         """Integer quantization with straight-through estimator."""
@@ -337,7 +337,7 @@ def build_genie_model(feat_dict,
   # Sequence embedding (single vector per sequence)
   if cfg.seq_emb_unconstrained:
     with tf.variable_scope("seq_emb_unconstrained"):
-      seq_emb_unconstrained = tf.layers.dense(
+      seq_emb_unconstrained = tf.keras.layers.dense(
           enc_seq, cfg.seq_emb_unconstrained_embedding_dim)
 
     out_dict["seq_emb_unconstrained"] = seq_emb_unconstrained
@@ -348,7 +348,7 @@ def build_genie_model(feat_dict,
   # Sequence embeddings (variational w/ reparameterization trick)
   if cfg.seq_emb_vae:
     with tf.variable_scope("seq_emb_vae"):
-      seq_emb_vae = tf.layers.dense(enc_seq, cfg.seq_emb_vae_embedding_dim * 2)
+      seq_emb_vae = tf.keras.layers.dense(enc_seq, cfg.seq_emb_vae_embedding_dim * 2)
 
       mean = seq_emb_vae[:, :cfg.seq_emb_vae_embedding_dim]
       stddev = 1e-6 + tf.nn.softplus(
@@ -378,7 +378,7 @@ def build_genie_model(feat_dict,
           batch_size, seq_len // cfg.lor_emb_n,
           cfg.lor_emb_n * rnn_embedding_dim
       ])
-      lor_emb_unconstrained = tf.layers.dense(
+      lor_emb_unconstrained = tf.keras.layers.dense(
           enc_lor, cfg.lor_emb_unconstrained_embedding_dim)
 
       out_dict["lor_emb_unconstrained"] = lor_emb_unconstrained
@@ -437,7 +437,7 @@ def build_genie_model(feat_dict,
         rnn_nunits=cfg.rnn_nunits)
 
     with tf.variable_scope("pitches"):
-      dec_recons_logits = tf.layers.dense(dec_stp, 88)
+      dec_recons_logits = tf.keras.layers.dense(dec_stp, 88)
 
     dec_recons_loss = weighted_avg(
         tf.nn.sparse_softmax_cross_entropy_with_logits(
@@ -455,7 +455,7 @@ def build_genie_model(feat_dict,
 
     if cfg.dec_pred_velocity:
       with tf.variable_scope("velocities"):
-        dec_recons_velocity_logits = tf.layers.dense(
+        dec_recons_velocity_logits = tf.keras.layers.dense(
             dec_stp, cfg.data_max_discrete_velocities + 1)
 
       dec_recons_velocity_loss = weighted_avg(

--- a/magenta/models/pianoroll_rnn_nade/pianoroll_rnn_nade_graph.py
+++ b/magenta/models/pianoroll_rnn_nade/pianoroll_rnn_nade_graph.py
@@ -65,14 +65,14 @@ class RnnNade(object):
   def __init__(self, rnn_cell, num_dims, num_hidden):
     self._num_dims = num_dims
     self._rnn_cell = rnn_cell
-    self._fc_layer = tf.layers.Dense(units=num_dims + num_hidden)
+    self._fc_layer = tf.keras.layers.Dense(units=num_dims + num_hidden)
     self._nade = Nade(num_dims, num_hidden)
 
   def _get_rnn_zero_state(self, batch_size):
     """Return a tensor or tuple of tensors for an initial rnn state."""
     return self._rnn_cell.zero_state(batch_size, tf.float32)
 
-  class SampleNadeLayer(tf.layers.Layer):
+  class SampleNadeLayer(tf.keras.layers.Layer):
     """Layer that computes samples from a NADE."""
 
     def __init__(self, nade, name=None, **kwargs):

--- a/magenta/models/svg_vae/image_vae.py
+++ b/magenta/models/svg_vae/image_vae.py
@@ -139,41 +139,41 @@ class ImageVAE(t2t_model.T2TModel):
       clss = tf.reshape(clss, [-1])
 
       # conv layer, followed by instance norm + FiLM
-      ret = tf.layers.Conv2D(hparams.base_depth, 5, 1,
+      ret = tf.keras.layers.Conv2D(hparams.base_depth, 5, 1,
                              padding='SAME', activation=None)(ret)
       ret = ops.conditional_instance_norm(ret, clss, hparams.num_categories)
       ret = tf.nn.relu(ret)
 
-      ret = tf.layers.Conv2D(hparams.base_depth, 5, 2,
+      ret = tf.keras.layers.Conv2D(hparams.base_depth, 5, 2,
                              padding='SAME', activation=None)(ret)
       ret = ops.conditional_instance_norm(ret, clss, hparams.num_categories)
       ret = tf.nn.relu(ret)
 
-      ret = tf.layers.Conv2D(2 * hparams.base_depth, 5, 1,
+      ret = tf.keras.layers.Conv2D(2 * hparams.base_depth, 5, 1,
                              padding='SAME', activation=None)(ret)
       ret = ops.conditional_instance_norm(ret, clss, hparams.num_categories)
       ret = tf.nn.relu(ret)
 
-      ret = tf.layers.Conv2D(2 * hparams.base_depth, 5, 2,
-                             padding='SAME', activation=None)(ret)
-      ret = ops.conditional_instance_norm(ret, clss, hparams.num_categories)
-      ret = tf.nn.relu(ret)
-
-      # new conv layer, to bring shape down
-      ret = tf.layers.Conv2D(2 * hparams.bottleneck_bits, 4, 2,
+      ret = tf.keras.layers.Conv2D(2 * hparams.base_depth, 5, 2,
                              padding='SAME', activation=None)(ret)
       ret = ops.conditional_instance_norm(ret, clss, hparams.num_categories)
       ret = tf.nn.relu(ret)
 
       # new conv layer, to bring shape down
-      ret = tf.layers.Conv2D(2 * hparams.bottleneck_bits, 4, 2,
+      ret = tf.keras.layers.Conv2D(2 * hparams.bottleneck_bits, 4, 2,
+                             padding='SAME', activation=None)(ret)
+      ret = ops.conditional_instance_norm(ret, clss, hparams.num_categories)
+      ret = tf.nn.relu(ret)
+
+      # new conv layer, to bring shape down
+      ret = tf.keras.layers.Conv2D(2 * hparams.bottleneck_bits, 4, 2,
                              padding='SAME', activation=None)(ret)
       ret = ops.conditional_instance_norm(ret, clss, hparams.num_categories)
       ret = tf.nn.relu(ret)
 
       # ret has 1024
-      ret = tf.layers.flatten(ret)
-      ret = tf.layers.dense(ret, 2 * hparams.bottleneck_bits, activation=None)
+      ret = tf.keras.layers.flatten(ret)
+      ret = tf.keras.layers.dense(ret, 2 * hparams.bottleneck_bits, activation=None)
 
     return ret
 
@@ -181,48 +181,48 @@ class ImageVAE(t2t_model.T2TModel):
     # goes from [batch, bottleneck_bits] to [batch, 64, 64, 1]
     with tf.variable_scope('visual_decoder', reuse=tf.AUTO_REUSE):
       # unbottleneck
-      ret = tf.layers.dense(bottleneck, 1024, activation=None)
+      ret = tf.keras.layers.dense(bottleneck, 1024, activation=None)
       ret = tf.reshape(ret, [-1, 4, 4, 64])
       clss = tf.reshape(clss, [-1])
 
       # new deconv to bring shape up
-      ret = tf.layers.Conv2DTranspose(2 * hparams.base_depth, 4, 2,
+      ret = tf.keras.layers.Conv2DTranspose(2 * hparams.base_depth, 4, 2,
                                       padding='SAME', activation=None)(ret)
       ret = ops.conditional_instance_norm(ret, clss, hparams.num_categories)
       ret = tf.nn.relu(ret)
 
       # new deconv to bring shape up
-      ret = tf.layers.Conv2DTranspose(2 * hparams.base_depth, 4, 2,
+      ret = tf.keras.layers.Conv2DTranspose(2 * hparams.base_depth, 4, 2,
                                       padding='SAME', activation=None)(ret)
       ret = ops.conditional_instance_norm(ret, clss, hparams.num_categories)
       ret = tf.nn.relu(ret)
 
-      ret = tf.layers.Conv2DTranspose(2 * hparams.base_depth, 5, padding='SAME',
+      ret = tf.keras.layers.Conv2DTranspose(2 * hparams.base_depth, 5, padding='SAME',
                                       activation=None)(ret)
       ret = ops.conditional_instance_norm(ret, clss, hparams.num_categories)
       ret = tf.nn.relu(ret)
 
-      ret = tf.layers.Conv2DTranspose(2 * hparams.base_depth, 5, 2,
+      ret = tf.keras.layers.Conv2DTranspose(2 * hparams.base_depth, 5, 2,
                                       padding='SAME', activation=None)(ret)
       ret = ops.conditional_instance_norm(ret, clss, hparams.num_categories)
       ret = tf.nn.relu(ret)
 
-      ret = tf.layers.Conv2DTranspose(hparams.base_depth, 5, padding='SAME',
+      ret = tf.keras.layers.Conv2DTranspose(hparams.base_depth, 5, padding='SAME',
                                       activation=None)(ret)
       ret = ops.conditional_instance_norm(ret, clss, hparams.num_categories)
       ret = tf.nn.relu(ret)
 
-      ret = tf.layers.Conv2DTranspose(hparams.base_depth, 5, 2, padding='SAME',
+      ret = tf.keras.layers.Conv2DTranspose(hparams.base_depth, 5, 2, padding='SAME',
                                       activation=None)(ret)
       ret = ops.conditional_instance_norm(ret, clss, hparams.num_categories)
       ret = tf.nn.relu(ret)
 
-      ret = tf.layers.Conv2DTranspose(hparams.base_depth, 5, padding='SAME',
+      ret = tf.keras.layers.Conv2DTranspose(hparams.base_depth, 5, padding='SAME',
                                       activation=None)(ret)
       ret = ops.conditional_instance_norm(ret, clss, hparams.num_categories)
       ret = tf.nn.relu(ret)
 
-      ret = tf.layers.Conv2D(1, 5, padding='SAME', activation=None)(ret)
+      ret = tf.keras.layers.Conv2D(1, 5, padding='SAME', activation=None)(ret)
 
       ret = tfd.Independent(tfd.Bernoulli(logits=ret),
                             reinterpreted_batch_ndims=3,

--- a/magenta/models/svg_vae/svg_decoder.py
+++ b/magenta/models/svg_vae/svg_decoder.py
@@ -198,7 +198,7 @@ class SVGDecoder(t2t_model.T2TModel):
 
       # RUN PRE-LSTM LAYER
       with tf.variable_scope('pre_decoder', reuse=tf.AUTO_REUSE):
-        inputs = tf.layers.dense(inputs, hparams.hidden_size, name='bottom')
+        inputs = tf.keras.layers.dense(inputs, hparams.hidden_size, name='bottom')
         inputs = tf.nn.tanh(inputs)
 
       # RUN LSTM
@@ -272,7 +272,7 @@ class SVGDecoder(t2t_model.T2TModel):
     inputs = tf.concat([inputs, overlay_x], -1)
 
     with tf.variable_scope('pre_decoder', reuse=tf.AUTO_REUSE):
-      inputs = tf.layers.dense(inputs, hparams.hidden_size, name='bottom')
+      inputs = tf.keras.layers.dense(inputs, hparams.hidden_size, name='bottom')
       inputs = tf.nn.tanh(inputs)
 
     with tf.variable_scope('lstm_decoder', reuse=tf.AUTO_REUSE):
@@ -295,7 +295,7 @@ class SVGDecoder(t2t_model.T2TModel):
 
   def unbottleneck(self, x, res_size, reuse=tf.AUTO_REUSE, name_append=''):
     with tf.variable_scope('unbottleneck{}'.format(name_append), reuse=reuse):
-      x = tf.layers.dense(x, res_size, name='dense', activation='tanh')
+      x = tf.keras.layers.dense(x, res_size, name='dense', activation='tanh')
       return x
 
   def create_initial_input_for_decode(self, batch_size):

--- a/magenta/models/svg_vae/svg_decoder_loss.py
+++ b/magenta/models/svg_vae/svg_decoder_loss.py
@@ -136,7 +136,7 @@ def real_svg_top(body_output, unused_targets, model_hparams, unused_vocab_size,
 
   # the 'hard' option is meant to be used if 'top' is called within body
   with tf.variable_scope('real_top', reuse=tf.AUTO_REUSE):
-    ret = tf.layers.dense(body_output, nout, name='top')
+    ret = tf.keras.layers.dense(body_output, nout, name='top')
     batch_size = common_layers.shape_list(ret)[0]
 
     if hard or model_hparams.mode == tf_estimator.ModeKeys.PREDICT:

--- a/magenta/scripts/abc_compare.py
+++ b/magenta/scripts/abc_compare.py
@@ -28,11 +28,12 @@ import re
 from note_seq import abc_parser
 from note_seq import midi_io
 from note_seq import sequences_lib
+from absl import app, flags
 import tensorflow.compat.v1 as tf
 
-FLAGS = tf.app.flags.FLAGS
+FLAGS = flags.FLAGS
 
-tf.app.flags.DEFINE_string('input_dir', None,
+flags.DEFINE_string('input_dir', None,
                            'Directory containing files to convert.')
 
 # pylint: disable=forgotten-debug-statement
@@ -91,7 +92,8 @@ class CompareDirectory(tf.test.TestCase):
         self.assertEqual(midi_ns.total_time, expanded_tune.total_time)
 
 
-def main(unused_argv):
+def main(argv):
+  del argv
   if not FLAGS.input_dir:
     tf.logging.fatal('--input_dir required')
     return
@@ -100,10 +102,5 @@ def main(unused_argv):
 
   CompareDirectory().compare_directory(input_dir)
 
-
-def console_entry_point():
-  tf.app.run(main)
-
-
 if __name__ == '__main__':
-  console_entry_point()
+  app.run(main)

--- a/magenta/scripts/convert_dir_to_note_sequences.py
+++ b/magenta/scripts/convert_dir_to_note_sequences.py
@@ -29,18 +29,19 @@ import os
 from note_seq import abc_parser
 from note_seq import midi_io
 from note_seq import musicxml_reader
+from absl import app, flags
 import tensorflow.compat.v1 as tf
 
-FLAGS = tf.app.flags.FLAGS
+FLAGS = flags.FLAGS
 
-tf.app.flags.DEFINE_string('input_dir', None,
+flags.DEFINE_string('input_dir', None,
                            'Directory containing files to convert.')
-tf.app.flags.DEFINE_string('output_file', None,
+flags.DEFINE_string('output_file', None,
                            'Path to output TFRecord file. Will be overwritten '
                            'if it already exists.')
-tf.app.flags.DEFINE_bool('recursive', False,
+flags.DEFINE_bool('recursive', False,
                          'Whether or not to recurse into subdirectories.')
-tf.app.flags.DEFINE_string('log', 'INFO',
+flags.DEFINE_string('log', 'INFO',
                            'The threshold for what messages will be logged '
                            'DEBUG, INFO, WARN, ERROR, or FATAL.')
 
@@ -235,7 +236,8 @@ def convert_directory(root_dir, output_file, recursive=False):
     convert_files(root_dir, '', writer, recursive)
 
 
-def main(unused_argv):
+def main(argv):
+  del argv
   tf.logging.set_verbosity(FLAGS.log)
 
   if not FLAGS.input_dir:
@@ -254,11 +256,6 @@ def main(unused_argv):
 
   convert_directory(input_dir, output_file, FLAGS.recursive)
 
-
-def console_entry_point():
-  tf.disable_v2_behavior()
-  tf.app.run(main)
-
-
 if __name__ == '__main__':
-  console_entry_point()
+  tf.disable_v2_behavior()
+  app.run(main)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
   "sk-video>=1.1.10",
   "sox>=1.5.0",
   "tensorflow>=2.14,<2.15",
-  "keras<3",
+  "keras>=3.5",
   "tensorflow-datasets>=4.9",
   "tensorflow-probability>=0.21",
   "tf_slim>=1.1.0",


### PR DESCRIPTION
## Summary
- update README install command for keras>=3.5
- require keras>=3.5 in pyproject
- convert example scripts to absl flags style
- replace deprecated tf.layers usages across modules

## Testing
- `pip install -e .[test]` *(fails: ResolutionImpossible due to conflicting dependencies)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'absl')*
- `pylint $(git ls-files '*.py' | head -n 1)` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840c3c2dc5c83308df6873144dd5a53