### PR TITLE
Update RNN cells to use keras APIs

### DIFF
--- a/magenta/contrib/rnn_test.py
+++ b/magenta/contrib/rnn_test.py
@@ -524,9 +524,9 @@ class LSTMBlockCellTest(tf.test.TestCase, parameterized.TestCase):
         m1 = tf.zeros([1, 2])
         m2 = tf.zeros([1, 2])
         m3 = tf.zeros([1, 2])
-        g, ((out_m0, out_m1), (out_m2, out_m3)) = rnn_cell.MultiRNNCell(
-            [contrib_rnn.LSTMBlockCell(2)
-             for _ in range(2)], state_is_tuple=True)(x, ((m0, m1), (m2, m3)))
+        cell = tf.keras.layers.StackedRNNCells(
+            [contrib_rnn.LSTMBlockCell(2) for _ in range(2)])
+        g, ((out_m0, out_m1), (out_m2, out_m3)) = cell(x, ((m0, m1), (m2, m3)))
         sess.run([tf.global_variables_initializer()])
         res = sess.run([g, out_m0, out_m1, out_m2, out_m3], {
             x.name: np.array([[1., 1.]]),
@@ -585,9 +585,9 @@ class LSTMBlockCellTest(tf.test.TestCase, parameterized.TestCase):
         m1 = tf.zeros([1, 2])
         m2 = tf.zeros([1, 2])
         m3 = tf.zeros([1, 2])
-        g, ((out_m0, out_m1), (out_m2, out_m3)) = rnn_cell.MultiRNNCell(
-            [rnn_cell.BasicLSTMCell(2, state_is_tuple=True) for _ in range(2)],
-            state_is_tuple=True)(x, ((m0, m1), (m2, m3)))
+        cell_basic = tf.keras.layers.StackedRNNCells(
+            [rnn_cell.BasicLSTMCell(2, state_is_tuple=True) for _ in range(2)])
+        g, ((out_m0, out_m1), (out_m2, out_m3)) = cell_basic(x, ((m0, m1), (m2, m3)))
         sess.run([tf.global_variables_initializer()])
         basic_res = sess.run([g, out_m0, out_m1, out_m2, out_m3], {
             x.name: x_values,
@@ -602,9 +602,9 @@ class LSTMBlockCellTest(tf.test.TestCase, parameterized.TestCase):
         m1 = tf.zeros([1, 2])
         m2 = tf.zeros([1, 2])
         m3 = tf.zeros([1, 2])
-        g, ((out_m0, out_m1), (out_m2, out_m3)) = rnn_cell.MultiRNNCell(
-            [contrib_rnn.LSTMBlockCell(2)
-             for _ in range(2)], state_is_tuple=True)(x, ((m0, m1), (m2, m3)))
+        cell_block = tf.keras.layers.StackedRNNCells(
+            [contrib_rnn.LSTMBlockCell(2) for _ in range(2)])
+        g, ((out_m0, out_m1), (out_m2, out_m3)) = cell_block(x, ((m0, m1), (m2, m3)))
         sess.run([tf.global_variables_initializer()])
         block_res = sess.run([g, out_m0, out_m1, out_m2, out_m3], {
             x.name: x_values,
@@ -635,12 +635,11 @@ class LSTMBlockCellTest(tf.test.TestCase, parameterized.TestCase):
         m1 = tf.zeros([1, 2])
         m2 = tf.zeros([1, 2])
         m3 = tf.zeros([1, 2])
-        g, ((out_m0, out_m1), (out_m2, out_m3)) = rnn_cell.MultiRNNCell(
-            [
+        cell_basic = tf.keras.layers.StackedRNNCells([
                 rnn_cell.LSTMCell(2, use_peepholes=True, state_is_tuple=True)
                 for _ in range(2)
-            ],
-            state_is_tuple=True)(x, ((m0, m1), (m2, m3)))
+            ])
+        g, ((out_m0, out_m1), (out_m2, out_m3)) = cell_basic(x, ((m0, m1), (m2, m3)))
         sess.run([tf.global_variables_initializer()])
         basic_res = sess.run([g, out_m0, out_m1, out_m2, out_m3], {
             x.name: x_values,
@@ -655,9 +654,9 @@ class LSTMBlockCellTest(tf.test.TestCase, parameterized.TestCase):
         m1 = tf.zeros([1, 2])
         m2 = tf.zeros([1, 2])
         m3 = tf.zeros([1, 2])
-        g, ((out_m0, out_m1), (out_m2, out_m3)) = rnn_cell.MultiRNNCell(
-            [contrib_rnn.LSTMBlockCell(2, use_peephole=True) for _ in range(2)],
-            state_is_tuple=True)(x, ((m0, m1), (m2, m3)))
+        cell_block = tf.keras.layers.StackedRNNCells([
+            contrib_rnn.LSTMBlockCell(2, use_peephole=True) for _ in range(2)])
+        g, ((out_m0, out_m1), (out_m2, out_m3)) = cell_block(x, ((m0, m1), (m2, m3)))
         sess.run([tf.global_variables_initializer()])
         block_res = sess.run([g, out_m0, out_m1, out_m2, out_m3], {
             x.name: x_values,
@@ -689,7 +688,7 @@ class LayerNormBasicLSTMCellTest(tf.test.TestCase):
         state1 = rnn_cell.LSTMStateTuple(c1, h1)
         state = (state0, state1)
         single_cell = lambda: contrib_rnn.LayerNormBasicLSTMCell(2)
-        cell = rnn_cell.MultiRNNCell([single_cell() for _ in range(2)])
+        cell = tf.keras.layers.StackedRNNCells([single_cell() for _ in range(2)])
         g, out_m = cell(x, state)
         sess.run([tf.global_variables_initializer()])
         res = sess.run(
@@ -757,7 +756,7 @@ class LayerNormBasicLSTMCellTest(tf.test.TestCase):
         state1 = rnn_cell.LSTMStateTuple(c1, h1)
         state = (state0, state1)
         single_cell = lambda: contrib_rnn.LayerNormBasicLSTMCell(2, layer_norm=False)  # pylint: disable=line-too-long
-        cell = rnn_cell.MultiRNNCell([single_cell() for _ in range(2)])
+        cell = tf.keras.layers.StackedRNNCells([single_cell() for _ in range(2)])
         g, out_m = cell(x, state)
         sess.run([tf.global_variables_initializer()])
         res = sess.run(
@@ -822,7 +821,7 @@ class LayerNormBasicLSTMCellTest(tf.test.TestCase):
         c1 = tf.zeros([1, 2])
         h1 = tf.zeros([1, 2])
         state1 = rnn_cell.LSTMStateTuple(c1, h1)
-        cell = rnn_cell.MultiRNNCell(
+        cell = tf.keras.layers.StackedRNNCells(
             [contrib_rnn.LayerNormBasicLSTMCell(2) for _ in range(2)])
         h, (s0, s1) = cell(x, (state0, state1))
         sess.run([tf.global_variables_initializer()])
@@ -860,7 +859,7 @@ class LayerNormBasicLSTMCellTest(tf.test.TestCase):
         c1 = tf.zeros([1, 2])
         h1 = tf.zeros([1, 2])
         state1 = rnn_cell.LSTMStateTuple(c1, h1)
-        cell = rnn_cell.MultiRNNCell([
+        cell = tf.keras.layers.StackedRNNCells([
             contrib_rnn.LayerNormBasicLSTMCell(
                 2, layer_norm=True, norm_gain=1.0, norm_shift=0.0)
             for _ in range(2)

--- a/magenta/models/music_vae/lstm_utils.py
+++ b/magenta/models/music_vae/lstm_utils.py
@@ -36,7 +36,7 @@ def rnn_cell(rnn_cell_size, dropout_keep_prob, residual, is_training=True):
         cell,
         input_keep_prob=dropout_keep_prob)
     cells.append(cell)
-  return rnn.MultiRNNCell(cells)
+  return tf.keras.layers.StackedRNNCells(cells)
 
 
 def build_bidirectional_lstm(

--- a/magenta/models/onsets_frames_transcription/model_tpu.py
+++ b/magenta/models/onsets_frames_transcription/model_tpu.py
@@ -102,7 +102,7 @@ def lstm_layer(inputs,
   else:
     with tf.variable_scope('lstm'):
       outputs, unused_state = tf.nn.dynamic_rnn(
-          cell=tf.nn.rnn_cell.MultiRNNCell(cells_fw),
+          cell=tf.keras.layers.StackedRNNCells(cells_fw),
           inputs=inputs,
           dtype=tf.float32,
           sequence_length=lengths,
@@ -163,7 +163,7 @@ def lstm_layer_static_for_tflite(inputs,
   else:  # not bidirectional
     with tf.variable_scope('lstm'):
       outputs, unused_state = tf.nn.static_rnn(
-          cell=tf.nn.rnn_cell.MultiRNNCell(cells_fw),
+          cell=tf.keras.layers.StackedRNNCells(cells_fw),
           inputs=prev_layer,
           sequence_length=lengths,
           dtype=tf.float32)

--- a/magenta/models/piano_genie/model.py
+++ b/magenta/models/piano_genie/model.py
@@ -39,7 +39,7 @@ def simple_lstm_encoder(features,
   else:
     raise NotImplementedError()
 
-  cell = rnn.MultiRNNCell(
+  cell = tf.keras.layers.StackedRNNCells(
       [celltype(rnn_nunits) for _ in range(rnn_nlayers)])
 
   with tf.variable_scope("rnn"):
@@ -81,7 +81,7 @@ def simple_lstm_decoder(features,
   else:
     raise NotImplementedError()
 
-  cell = rnn.MultiRNNCell(
+  cell = tf.keras.layers.StackedRNNCells(
       [celltype(rnn_nunits) for _ in range(rnn_nlayers)])
 
   with tf.variable_scope("rnn"):

--- a/magenta/models/rl_tuner/rl_tuner_ops.py
+++ b/magenta/models/rl_tuner/rl_tuner_ops.py
@@ -307,7 +307,7 @@ def make_rnn_cell(rnn_layer_sizes, state_is_tuple=False):
     cell = tf.nn.rnn_cell.LSTMCell(num_units, state_is_tuple=state_is_tuple)
     cells.append(cell)
 
-  cell = tf.nn.rnn_cell.MultiRNNCell(cells, state_is_tuple=state_is_tuple)
+  cell = tf.keras.layers.StackedRNNCells(cells)
 
   return cell
 

--- a/magenta/models/shared/events_rnn_graph.py
+++ b/magenta/models/shared/events_rnn_graph.py
@@ -60,7 +60,7 @@ def make_rnn_cell(rnn_layer_sizes,
         cell, output_keep_prob=dropout_keep_prob)
     cells.append(cell)
 
-  cell = rnn.MultiRNNCell(cells)
+  cell = tf.keras.layers.StackedRNNCells(cells)
 
   return cell
 

--- a/magenta/models/svg_vae/svg_decoder.py
+++ b/magenta/models/svg_vae/svg_decoder.py
@@ -137,7 +137,7 @@ class SVGDecoder(t2t_model.T2TModel):
     batch_size = common_layers.shape_list(inputs)[0]
     zero_pad, logits_so_far = self.create_initial_input_for_decode(batch_size)
 
-    layers = rnn.MultiRNNCell([
+    layers = tf.keras.layers.StackedRNNCells([
         self.lstm_cell(hparams, train) for _ in range(hparams.num_hidden_layers)
     ])
 
@@ -243,7 +243,7 @@ class SVGDecoder(t2t_model.T2TModel):
   def lstm_decoder(self, inputs, sequence_length, hparams, clss, train,
                    initial_state=None, bottleneck=None):
     # NOT IN PREDICT MODE. JUST RUN TEACHER-FORCED RNN:
-    layers = rnn.MultiRNNCell([
+    layers = tf.keras.layers.StackedRNNCells([
         self.lstm_cell(hparams, train) for _ in range(hparams.num_hidden_layers)
     ])
 


### PR DESCRIPTION
## Summary
- add `CompatRNNCell` base class and `LSTMStateTuple`
- refactor cell wrappers to use keras weights
- switch to `tf.keras.layers.StackedRNNCells` and update callers
- adjust unit tests for new API

## Testing
- `pytest magenta/contrib/rnn_test.py::RNNCellTest::testInputProjectionWrapper -vv` *(fails: ModuleNotFoundError: No module named 'tensorflow_probability')*

------
https://chatgpt.com/codex/tasks/task_e_6841bde1dd008330abd18b6d06cd243b