### PR TITLE
Align Keras requirement with pyproject

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Work in progress to update Magenta to run on current Colab (Python 3.11)
 Magenta currently supports **Python 3.11**. Install it with pip and ensure TensorFlow 2.18 is selected:
 
 ```bash
-pip install magenta "tensorflow>=2.18,<2.19" "keras<3"
+pip install magenta "tensorflow>=2.18,<2.19" "keras>=3.5,<4"
 ```
 
-TensorFlow 2.19+ is not yet supported, and Python versions newer than 3.11 are incompatible.
+TensorFlow 2.19+ is not yet supported, and Python versions newer than 3.11 are incompatible. Magenta now requires **Keras 3**. If upgrading from Keras 2, see the [migration guide](https://keras.io/guides/migrating_to_keras_3/).

--- a/magenta/version.py
+++ b/magenta/version.py
@@ -18,4 +18,4 @@ Stored in a separate file so that setup.py can reference the version without
 pulling in all the dependencies in __init__.py.
 """
 
-__version__ = '2.1.4+yolo2'
+__version__ = '2.1.5+yolo2'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "magenta"
-version = "2.1.4+yolo2"
+version = "2.1.5+yolo2"
 description = "Use machine learning to create art and music"
 readme = "README.md"
 requires-python = ">=3.11,<3.12"
@@ -47,7 +47,7 @@ dependencies = [
   "sk-video>=1.1.10",
   "sox>=1.5.0",
   "tensorflow>=2.18,<2.19",
-  "keras>=3.5",
+  "keras>=3.5,<4",
   "tensorflow-datasets>=4.9",
   "tensorflow-probability>=0.25",
   "tf_slim>=1.1.0",


### PR DESCRIPTION
## Summary
- require Keras 3 and mention migration guide in README
- pin Keras version range in `pyproject.toml`
- bump version to 2.1.5+yolo2

## Testing
- `pip install -e .[test]` *(fails: Operation cancelled)*
- `pytest --ignore=magenta/models/score2perf` *(fails: errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6841c743343c8330b1e8a816edbcd5a3