### PR TITLE
Fix TensorFlow 1.x APIs

### DIFF
--- a/magenta/common/nade.py
+++ b/magenta/common/nade.py
@@ -210,7 +210,7 @@ class Nade(object):
       cond_p_i, cond_l_i = self._cond_prob(a, w_dec_i, b_dec_i)
 
       if temperature is None:
-        v_i = tf.to_float(tf.greater_equal(cond_p_i, 0.5))
+        v_i = tf.cast(tf.greater_equal(cond_p_i, 0.5, tf.float32))
       else:
         bernoulli = tfp.distributions.Bernoulli(
             logits=cond_l_i / temperature, dtype=tf.float32)

--- a/magenta/common/tf_utils.py
+++ b/magenta/common/tf_utils.py
@@ -60,8 +60,8 @@ def log_loss(labels, predictions, epsilon=1e-7, scope=None, weights=None):
     ValueError: If the shape of `predictions` doesn't match that of `labels`.
   """
   with tf.name_scope(scope, "log_loss", (predictions, labels)):
-    predictions = tf.to_float(predictions)
-    labels = tf.to_float(labels)
+    predictions = tf.cast(predictions, tf.float32)
+    labels = tf.cast(labels, tf.float32)
     predictions.get_shape().assert_is_compatible_with(labels.get_shape())
     losses = -tf.multiply(labels, tf.log(predictions + epsilon)) - tf.multiply(
         (1 - labels), tf.log(1 - predictions + epsilon))

--- a/magenta/contrib/seq2seq_test.py
+++ b/magenta/contrib/seq2seq_test.py
@@ -492,7 +492,7 @@ class BasicDecoderTest(tf.test.TestCase):
     sample_fn = (
         lambda x: seq2seq.bernoulli_sample(logits=x, dtype=tf.bool))
     # The next inputs are a one-hot encoding of the sampled labels.
-    next_inputs_fn = tf.to_float
+    next_inputs_fn = lambda x: tf.cast(x, tf.float32)
     end_fn = lambda sample_ids: sample_ids[:, end_token]
 
     with self.session(use_gpu=True) as sess:

--- a/magenta/models/coconet/lib_graph.py
+++ b/magenta/models/coconet/lib_graph.py
@@ -164,9 +164,9 @@ class CoconetGraph(object):
     # construct mask to identify zero padding that was introduced to
     # make the batch rectangular
     batch_duration = tf.shape(self.pianorolls)[1]
-    indices = tf.to_float(tf.range(batch_duration))
-    pad_mask = tf.to_float(
-        indices[None, :, None, None] < self.lengths[:, None, None, None])
+    indices = tf.cast(tf.range(batch_duration, tf.float32))
+    pad_mask = tf.cast(
+        indices[None, :, None, None] < self.lengths[:, None, None, None], tf.float32)
 
     # construct mask and its complement, respecting pad mask
     mask = pad_mask * self.masks
@@ -176,8 +176,8 @@ class CoconetGraph(object):
     # #timesteps * #variables per timestep
     variable_axis = 3 if self.hparams.use_softmax_loss else 2
     dd = (
-        self.lengths[:, None, None, None] * tf.to_float(
-            tf.shape(self.pianorolls)[variable_axis]))
+        self.lengths[:, None, None, None] * tf.cast(
+            tf.shape(self.pianorolls, tf.float32)[variable_axis]))
     reduced_dd = tf.reduce_sum(dd)
 
     # Compute numbers of variables to be predicted/conditioned on

--- a/magenta/models/gansynth/lib/datasets.py
+++ b/magenta/models/gansynth/lib/datasets.py
@@ -83,7 +83,7 @@ class NSynthTfdsDataset(BaseDataset):
     pitches = sorted(pitch_counts.keys())
     counts = [pitch_counts[p] for p in pitches]
     indices = tf.reshape(
-        tf.multinomial(tf.log([tf.to_float(counts)]), batch_size), [batch_size])
+        tf.multinomial(tf.log([tf.cast(counts, tf.float32)]), batch_size), [batch_size])
     one_hot_labels = tf.one_hot(indices, depth=len(pitches))
     return one_hot_labels
 

--- a/magenta/models/gansynth/lib/networks.py
+++ b/magenta/models/gansynth/lib/networks.py
@@ -166,10 +166,11 @@ def compute_progress(current_image_id, stable_stage_num_images,
   progress_integer = tf.floordiv(capped_current_image_id, stage_num_images)
   progress_fraction = tf.maximum(
       0.0,
-      tf.to_float(
+      tf.cast(
           tf.mod(capped_current_image_id, stage_num_images) -
-          stable_stage_num_images) / tf.to_float(transition_stage_num_images))
-  return tf.to_float(progress_integer) + progress_fraction
+          stable_stage_num_images, tf.float32) /
+      tf.cast(transition_stage_num_images, tf.float32))
+  return tf.cast(progress_integer, tf.float32) + progress_fraction
 
 
 def compute_progress_from_time(train_time, num_resolutions,

--- a/magenta/models/gansynth/lib/specgrams_helper.py
+++ b/magenta/models/gansynth/lib/specgrams_helper.py
@@ -202,7 +202,7 @@ class SpecgramsHelper(object):
     mag2 = tf.exp(2.0 * logmag)
     phase_angle = tf.cumsum(p * np.pi, axis=-2)
 
-    l2mel = tf.to_float(self._linear_to_mel_matrix())
+    l2mel = tf.cast(self._linear_to_mel_matrix(), tf.float32)
     logmelmag2 = self._safe_log(tf.tensordot(mag2, l2mel, 1))
     mel_phase_angle = tf.tensordot(phase_angle, l2mel, 1)
     mel_p = spectral_ops.instantaneous_frequency(mel_phase_angle)
@@ -227,7 +227,7 @@ class SpecgramsHelper(object):
     logmelmag2 = melspecgrams[:, :, :, 0]
     mel_p = melspecgrams[:, :, :, 1]
 
-    mel2l = tf.to_float(self._mel_to_linear_matrix())
+    mel2l = tf.cast(self._mel_to_linear_matrix(), tf.float32)
     mag2 = tf.tensordot(tf.exp(logmelmag2), mel2l, 1)
     logmag = 0.5 * self._safe_log(mag2)
     mel_phase_angle = tf.cumsum(mel_p * np.pi, axis=-2)

--- a/magenta/models/gansynth/lib/spectral_ops.py
+++ b/magenta/models/gansynth/lib/spectral_ops.py
@@ -254,14 +254,14 @@ def crop_or_pad(waves, length, channels):
 
   # Force audio length.
   pad = tf.maximum(0, length - waves_shape[1])
-  right_pad = tf.to_int32(tf.to_float(pad) / 2.0)
+  right_pad = tf.to_int32(tf.cast(pad, tf.float32) / 2.0)
   left_pad = pad - right_pad
   waves = tf.pad(waves, [[0, 0], [left_pad, right_pad], [0, 0]])
   waves = waves[:, :length, :]
 
   # Force number of channels.
   num_repeats = tf.to_int32(
-      tf.ceil(tf.to_float(channels) / tf.to_float(waves_shape[2])))
+      tf.ceil(tf.cast(channels, tf.float32) / tf.cast(waves_shape[2], tf.float32)))
   waves = tf.tile(waves, [1, 1, num_repeats])[:, :, :channels]
 
   waves.set_shape([batch_size, length, channels])

--- a/magenta/models/gansynth/lib/train_util.py
+++ b/magenta/models/gansynth/lib/train_util.py
@@ -169,7 +169,7 @@ def make_interpolated_latent_vectors(num_rows, num_columns, **kwargs):
   for _ in range(num_rows):
     z = tf.random_normal([2, kwargs['latent_vector_size']])
     r = tf.reshape(
-        tf.to_float(tf.range(num_columns)) / (num_columns - 1), [-1, 1])
+        tf.cast(tf.range(num_columns), tf.float32) / (num_columns - 1), [-1, 1])
     dz = z[1] - z[0]
     ans.append(z[0] + tf.stack([dz] * num_columns) * r)
   return tf.concat(ans, axis=0)

--- a/magenta/models/image_stylization/image_stylization_create_dataset.py
+++ b/magenta/models/image_stylization/image_stylization_create_dataset.py
@@ -77,7 +77,7 @@ def main(unused_argv):
       if FLAGS.compute_gram_matrices:
         with tf.Graph().as_default():
           style_end_points = learning.precompute_gram_matrices(
-              tf.expand_dims(tf.to_float(style_image), 0),
+              tf.expand_dims(tf.cast(style_image, tf.float32), 0),
               # We use 'pool5' instead of 'fc8' because a) fully-connected
               # layers are already too deep in the network to be useful for
               # style and b) they're quite expensive to store.

--- a/magenta/models/image_stylization/image_utils.py
+++ b/magenta/models/image_stylization/image_utils.py
@@ -107,7 +107,7 @@ def imagenet_inputs(batch_size, image_size, num_readers=1,
       image = _central_crop([image], image_size, image_size)[0]
       # pylint: enable=protected-access
       image.set_shape([image_size, image_size, 3])
-      image = tf.to_float(image) / 255.0
+      image = tf.cast(image, tf.float32) / 255.0
 
       images_and_labels.append([image, label_index])
 
@@ -208,7 +208,7 @@ def style_image_inputs(style_dataset_file, batch_size=None, image_size=None,
       else:
         image = _aspect_preserving_resize(image, image_size)
 
-    image = tf.to_float(image) / 255.0
+    image = tf.cast(image, tf.float32) / 255.0
 
     if batch_size is None:
       image = tf.expand_dims(image, 0)
@@ -346,8 +346,8 @@ def arbitrary_style_image_inputs(style_dataset_file,
           image = _aspect_preserving_resize(image, image_size)
           image_orig = image
 
-      image = tf.to_float(image) / 255.0
-      image_orig = tf.to_float(image_orig) / 255.0
+      image = tf.cast(image, tf.float32) / 255.0
+      image_orig = tf.cast(image_orig, tf.float32) / 255.0
 
       if batch_size is None:
         image = tf.expand_dims(image, 0)
@@ -438,7 +438,7 @@ def load_image(image_file, image_size=None):
     image = tf.image.resize_image_with_crop_or_pad(
         image, small_side, small_side)
     image = tf.image.resize_images(image, [image_size, image_size])
-  image = tf.to_float(image) / 255.0
+  image = tf.cast(image, tf.float32) / 255.0
 
   return tf.expand_dims(image, 0)
 
@@ -602,9 +602,9 @@ def _smallest_size_at_least(height, width, smallest_side):
   """
   smallest_side = tf.convert_to_tensor(smallest_side, dtype=tf.int32)
 
-  height = tf.to_float(height)
-  width = tf.to_float(width)
-  smallest_side = tf.to_float(smallest_side)
+  height = tf.cast(height, tf.float32)
+  width = tf.cast(width, tf.float32)
+  smallest_side = tf.cast(smallest_side, tf.float32)
 
   scale = tf.cond(tf.greater(height, width),
                   lambda: smallest_side / width,
@@ -731,7 +731,7 @@ def center_crop_resize_image(image, image_size):
   shape = tf.shape(image)
   small_side = tf.minimum(shape[0], shape[1])
   image = tf.image.resize_image_with_crop_or_pad(image, small_side, small_side)
-  image = tf.to_float(image) / 255.0
+  image = tf.cast(image, tf.float32) / 255.0
 
   image = tf.image.resize_images(image, tf.constant([image_size, image_size]))
 
@@ -750,6 +750,6 @@ def resize_image(image, image_size):
     with values in [0, 1].
   """
   image = _aspect_preserving_resize(image, image_size)
-  image = tf.to_float(image) / 255.0
+  image = tf.cast(image, tf.float32) / 255.0
 
   return tf.expand_dims(image, 0)

--- a/magenta/models/image_stylization/learning.py
+++ b/magenta/models/image_stylization/learning.py
@@ -173,13 +173,13 @@ def total_variation_loss(stylized_inputs, total_variation_weight):
   height = shape[1]
   width = shape[2]
   channels = shape[3]
-  y_size = tf.to_float((height - 1) * width * channels)
-  x_size = tf.to_float(height * (width - 1) * channels)
+  y_size = tf.cast((height - 1, tf.float32) * width * channels)
+  x_size = tf.cast(height * (width - 1, tf.float32) * channels)
   y_loss = tf.nn.l2_loss(
       stylized_inputs[:, 1:, :, :] - stylized_inputs[:, :-1, :, :]) / y_size
   x_loss = tf.nn.l2_loss(
       stylized_inputs[:, :, 1:, :] - stylized_inputs[:, :, :-1, :]) / x_size
-  loss = (y_loss + x_loss) / tf.to_float(batch_size)
+  loss = (y_loss + x_loss) / tf.cast(batch_size, tf.float32)
   weighted_loss = loss * total_variation_weight
   return weighted_loss, {
       'total_variation_loss': loss,
@@ -190,7 +190,7 @@ def total_variation_loss(stylized_inputs, total_variation_weight):
 def gram_matrix(feature_maps):
   """Computes the Gram matrix for a set of feature maps."""
   batch_size, height, width, channels = tf.unstack(tf.shape(feature_maps))
-  denominator = tf.to_float(height * width)
+  denominator = tf.cast(height * width, tf.float32)
   feature_maps = tf.reshape(
       feature_maps, tf.stack([batch_size, height * width, channels]))
   matrix = tf.matmul(feature_maps, feature_maps, adjoint_a=True)

--- a/magenta/models/music_vae/base_model.py
+++ b/magenta/models/music_vae/base_model.py
@@ -186,9 +186,9 @@ class MusicVAE(object):
     hparams = self.hparams
     z_size = hparams.z_size
 
-    sequence = tf.to_float(sequence)
+    sequence = tf.cast(sequence, tf.float32)
     if control_sequence is not None:
-      control_sequence = tf.to_float(control_sequence)
+      control_sequence = tf.cast(control_sequence, tf.float32)
       sequence = tf.concat([sequence, control_sequence], axis=-1)
     encoder_output = self.encoder.encode(sequence, sequence_length)
 
@@ -212,8 +212,8 @@ class MusicVAE(object):
     hparams = self.hparams
     batch_size = hparams.batch_size
 
-    input_sequence = tf.to_float(input_sequence)
-    output_sequence = tf.to_float(output_sequence)
+    input_sequence = tf.cast(input_sequence, tf.float32)
+    output_sequence = tf.cast(output_sequence, tf.float32)
 
     max_seq_len = tf.minimum(tf.shape(output_sequence)[1], hparams.max_seq_len)
 
@@ -221,7 +221,7 @@ class MusicVAE(object):
 
     if control_sequence is not None:
       control_depth = control_sequence.shape[-1]
-      control_sequence = tf.to_float(control_sequence)
+      control_sequence = tf.cast(control_sequence, tf.float32)
       control_sequence = control_sequence[:, :max_seq_len]
       # Shouldn't be necessary, but the slice loses shape information when
       # control depth is zero.
@@ -257,7 +257,7 @@ class MusicVAE(object):
     free_nats = hparams.free_bits * tf.math.log(2.0)
     kl_cost = tf.maximum(kl_div - free_nats, 0)
 
-    beta = ((1.0 - tf.pow(hparams.beta_rate, tf.to_float(self.global_step)))
+    beta = ((1.0 - tf.pow(hparams.beta_rate, tf.cast(self.global_step, tf.float32)))
             * hparams.max_beta)
     self.loss = tf.reduce_mean(r_loss) + beta * tf.reduce_mean(kl_cost)
 
@@ -292,7 +292,7 @@ class MusicVAE(object):
 
     hparams = self.hparams
     lr = ((hparams.learning_rate - hparams.min_learning_rate) *
-          tf.pow(hparams.decay_rate, tf.to_float(self.global_step)) +
+          tf.pow(hparams.decay_rate, tf.cast(self.global_step, tf.float32)) +
           hparams.min_learning_rate)
 
     optimizer = tf.train.AdamOptimizer(lr)

--- a/magenta/models/music_vae/lstm_utils.py
+++ b/magenta/models/music_vae/lstm_utils.py
@@ -142,26 +142,26 @@ def get_sampling_probability(hparams, is_training):
 
   schedule = hparams.sampling_schedule
   rate = hparams.sampling_rate
-  step = tf.to_float(tf.train.get_global_step())
+  step = tf.cast(tf.train.get_global_step(, tf.float32))
 
   if schedule == 'constant':
     if not 0 <= rate <= 1:
       raise ValueError(
           '`constant` sampling rate must be in the interval [0, 1]. Got %f.'
           % rate)
-    sampling_probability = tf.to_float(rate)
+    sampling_probability = tf.cast(rate, tf.float32)
   elif schedule == 'inverse_sigmoid':
     if rate < 1:
       raise ValueError(
           '`inverse_sigmoid` sampling rate must be at least 1. Got %f.' % rate)
-    k = tf.to_float(rate)
+    k = tf.cast(rate, tf.float32)
     sampling_probability = 1.0 - k / (k + tf.exp(step / k))
   elif schedule == 'exponential':
     if not 0 < rate < 1:
       raise ValueError(
           '`exponential` sampling rate must be in the interval (0, 1). Got %f.'
           % hparams.sampling_rate)
-    k = tf.to_float(rate)
+    k = tf.cast(rate, tf.float32)
     sampling_probability = 1.0 - tf.pow(k, step)
   else:
     raise ValueError('Invalid `sampling_schedule`: %s' % schedule)

--- a/magenta/models/nsynth/utils.py
+++ b/magenta/models/nsynth/utils.py
@@ -388,7 +388,7 @@ def tf_specgram(audio,
                 dphase=True,
                 mag_only=False):
   """Specgram tensorflow op (uses pyfunc)."""
-  return tf.py_func(batch_specgram, [
+  return tf.py_function(batch_specgram, [
       audio, n_fft, hop_length, mask, log_mag, re_im, dphase, mag_only
   ], tf.float32)
 
@@ -410,7 +410,7 @@ def tf_ispecgram(spec,
     x = tf.concat([spec, tf.zeros([dims[0], 1, dims[2], dims[3]])], 1)
   else:
     x = spec
-  audio = tf.py_func(batch_ispecgram, [
+  audio = tf.py_function(batch_ispecgram, [
       x, n_fft, hop_length, mask, log_mag, re_im, dphase, mag_only, num_iters
   ], tf.float32)
   return audio
@@ -588,10 +588,10 @@ def softmax_summaries(loss, logits, one_hot_labels, name="softmax"):
 
   in_top_1 = tf.nn.in_top_k(logits, one_hot_labels, 1)
   tf.summary.scalar(name + "_precision@1",
-                    tf.reduce_mean(tf.to_float(in_top_1)))
+                    tf.reduce_mean(tf.cast(in_top_1, tf.float32)))
   in_top_5 = tf.nn.in_top_k(logits, one_hot_labels, 5)
   tf.summary.scalar(name + "_precision@5",
-                    tf.reduce_mean(tf.to_float(in_top_5)))
+                    tf.reduce_mean(tf.cast(in_top_5, tf.float32)))
 
 
 def calculate_l2_and_summaries(predicted_vectors, true_vectors, name):

--- a/magenta/models/onsets_frames_transcription/data.py
+++ b/magenta/models/onsets_frames_transcription/data.py
@@ -131,7 +131,7 @@ def wav_to_spec_op(wav_audio, hparams):
     assert hparams.spec_log_amplitude
     spec = tflite_compat_mel(wav_audio, hparams=hparams)
   else:
-    spec = tf.py_func(
+    spec = tf.py_function(
         functools.partial(wav_to_spec, hparams=hparams),
         [wav_audio],
         tf.float32,
@@ -177,7 +177,7 @@ def get_spectrogram_hash_op(spectrogram):
     spectrogram_hash = np.int64(zlib.adler32(spectrogram_serialized.getvalue()))
     spectrogram_serialized.close()
     return spectrogram_hash
-  spectrogram_hash = tf.py_func(get_spectrogram_hash, [spectrogram], tf.int64,
+  spectrogram_hash = tf.py_function(get_spectrogram_hash, [spectrogram], tf.int64,
                                 name='get_spectrogram_hash')
   spectrogram_hash.set_shape([])
   return spectrogram_hash
@@ -191,7 +191,7 @@ def wav_to_num_frames(wav_audio, frames_per_second):
 
 def wav_to_num_frames_op(wav_audio, frames_per_second):
   """Transforms a wav-encoded audio string into number of frames."""
-  res = tf.py_func(
+  res = tf.py_function(
       functools.partial(wav_to_num_frames, frames_per_second=frames_per_second),
       [wav_audio],
       tf.int32,
@@ -212,7 +212,7 @@ def transform_wav_data_op(wav_data_tensor, hparams, jitter_amount_sec):
 
     return [wav_data]
 
-  return tf.py_func(
+  return tf.py_function(
       transform_wav_data, [wav_data_tensor],
       tf.string,
       name='transform_wav_data_op')
@@ -241,7 +241,7 @@ def sequence_to_pianoroll_op(sequence_tensor, velocity_range_tensor, hparams):
     return (roll.active, roll.weights, roll.onsets, roll.onset_velocities,
             roll.offsets)
 
-  res, weighted_res, onsets, velocities, offsets = tf.py_func(
+  res, weighted_res, onsets, velocities, offsets = tf.py_function(
       sequence_to_pianoroll_fn, [sequence_tensor, velocity_range_tensor],
       [tf.float32, tf.float32, tf.float32, tf.float32, tf.float32],
       name='sequence_to_pianoroll_op')
@@ -261,7 +261,7 @@ def jitter_label_op(sequence_tensor, jitter_amount_sec):
     sequence = sequences_lib.shift_sequence_times(sequence, jitter_amount_sec)
     return sequence.SerializeToString()
 
-  return tf.py_func(jitter_label, [sequence_tensor], tf.string)
+  return tf.py_function(jitter_label, [sequence_tensor], tf.string)
 
 
 def truncate_note_sequence(sequence, truncate_secs):
@@ -296,7 +296,7 @@ def truncate_note_sequence_op(sequence_tensor, truncated_length_frames,
     sequence = music_pb2.NoteSequence.FromString(sequence_tensor)
     num_secs = num_frames / hparams_frames_per_second(hparams)
     return truncate_note_sequence(sequence, num_secs).SerializeToString()
-  res = tf.py_func(
+  res = tf.py_function(
       truncate,
       [sequence_tensor, truncated_length_frames],
       tf.string)
@@ -526,7 +526,7 @@ def input_tensors_to_model_input(
           reduce_mode='max',
           min_pitch=constants.MIN_MIDI_PITCH)
     if labels_dict['note_sequence'].dtype == tf.string:
-      labels_dict['note_sequence'] = tf.py_func(
+      labels_dict['note_sequence'] = tf.py_function(
           functools.partial(
               drum_mappings.map_sequences, mapping_name=hparams.drum_data_map),
           [labels_dict['note_sequence']],

--- a/magenta/models/onsets_frames_transcription/estimator_spec_util.py
+++ b/magenta/models/onsets_frames_transcription/estimator_spec_util.py
@@ -118,7 +118,7 @@ def _predict_sequences(frame_probs, onset_probs, frame_predictions,
 
   sequences = []
   for i in range(frame_predictions.shape[0]):
-    sequence = tf.py_func(
+    sequence = tf.py_function(
         functools.partial(predict_sequence, hparams=hparams),
         inp=[
             frame_probs[i],

--- a/magenta/models/onsets_frames_transcription/metrics.py
+++ b/magenta/models/onsets_frames_transcription/metrics.py
@@ -68,18 +68,18 @@ def calculate_frame_metrics(frame_labels, frame_predictions):
   frame_labels_bool = tf.cast(frame_labels, tf.bool)
   frame_predictions_bool = tf.cast(frame_predictions, tf.bool)
 
-  frame_true_positives = tf.reduce_sum(tf.to_float(tf.logical_and(
+  frame_true_positives = tf.reduce_sum(tf.cast(tf.logical_and(
       tf.equal(frame_labels_bool, True),
-      tf.equal(frame_predictions_bool, True))))
-  frame_false_positives = tf.reduce_sum(tf.to_float(tf.logical_and(
+      tf.equal(frame_predictions_bool, True)), tf.float32))
+  frame_false_positives = tf.reduce_sum(tf.cast(tf.logical_and(
       tf.equal(frame_labels_bool, False),
-      tf.equal(frame_predictions_bool, True))))
-  frame_false_negatives = tf.reduce_sum(tf.to_float(tf.logical_and(
+      tf.equal(frame_predictions_bool, True)), tf.float32))
+  frame_false_negatives = tf.reduce_sum(tf.cast(tf.logical_and(
       tf.equal(frame_labels_bool, True),
-      tf.equal(frame_predictions_bool, False))))
+      tf.equal(frame_predictions_bool, False)), tf.float32))
   frame_accuracy = (
       tf.reduce_sum(
-          tf.to_float(tf.equal(frame_labels_bool, frame_predictions_bool))) /
+          tf.cast(tf.equal(frame_labels_bool, frame_predictions_bool), tf.float32)) /
       tf.cast(tf.size(frame_labels), tf.float32))
 
   frame_precision = tf.where(
@@ -313,7 +313,7 @@ def calculate_metrics(frame_probs,
    note_with_velocity_f1, note_with_offsets_precision, note_with_offsets_recall,
    note_with_offsets_f1, note_with_offsets_velocity_precision,
    note_with_offsets_velocity_recall, note_with_offsets_velocity_f1,
-   processed_frame_predictions) = tf.py_func(
+   processed_frame_predictions) = tf.py_function(
        functools.partial(
            _calculate_metrics_py,
            hparams=hparams,
@@ -352,7 +352,7 @@ def calculate_metrics(frame_probs,
        note_with_velocity_f1, note_with_offsets_precision,
        note_with_offsets_recall, note_with_offsets_f1,
        note_with_offsets_velocity_precision, note_with_offsets_velocity_recall,
-       note_with_offsets_velocity_f1, processed_frame_predictions) = tf.py_func(
+       note_with_offsets_velocity_f1, processed_frame_predictions) = tf.py_function(
            functools.partial(
                _calculate_metrics_py,
                hparams=hparams,

--- a/magenta/models/onsets_frames_transcription/model.py
+++ b/magenta/models/onsets_frames_transcription/model.py
@@ -334,7 +334,7 @@ def model_fn(features, labels, mode, params, config):
           min_pitch=constants.MIN_MIDI_PITCH)
       return sequence.SerializeToString()
 
-    sequence = tf.py_func(
+    sequence = tf.py_function(
         _predict,
         inp=[
             frame_probs[0],

--- a/magenta/models/piano_genie/loader.py
+++ b/magenta/models/piano_genie/loader.py
@@ -128,7 +128,7 @@ def load_noteseqs(fp,
   # Deserialize protos
   # pylint: disable=g-long-lambda
   dataset = dataset.map(
-      lambda data: tf.py_func(
+      lambda data: tf.py_function(
           lambda x: _str_to_tensor(
               x, augment_stretch_bounds, augment_transpose_bounds),
           [data], (tf.string, tf.float32), stateful=False))

--- a/magenta/models/pianoroll_rnn_nade/pianoroll_rnn_nade_graph.py
+++ b/magenta/models/pianoroll_rnn_nade/pianoroll_rnn_nade_graph.py
@@ -270,15 +270,15 @@ def get_build_graph_fn(mode, config, sequence_example_file_paths=None):
     if mode in ('train', 'eval'):
       log_probs, cond_probs = rnn_nade.log_prob(inputs, lengths)
 
-      inputs_flat = tf.to_float(
-          magenta.common.flatten_maybe_padded_sequences(inputs, lengths))
-      predictions_flat = tf.to_float(tf.greater_equal(cond_probs, .5))
+      inputs_flat = tf.cast(
+          magenta.common.flatten_maybe_padded_sequences(inputs, lengths), tf.float32)
+      predictions_flat = tf.cast(tf.greater_equal(cond_probs, .5), tf.float32)
 
       if mode == 'train':
         loss = tf.reduce_mean(-log_probs)
         perplexity = tf.reduce_mean(tf.exp(log_probs))
-        correct_predictions = tf.to_float(
-            tf.equal(inputs_flat, predictions_flat))
+        correct_predictions = tf.cast(
+            tf.equal(inputs_flat, predictions_flat), tf.float32)
         accuracy = tf.reduce_mean(correct_predictions)
         precision = (tf.reduce_sum(inputs_flat * predictions_flat) /
                      tf.reduce_sum(predictions_flat))

--- a/magenta/models/score2perf/modalities.py
+++ b/magenta/models/score2perf/modalities.py
@@ -52,7 +52,7 @@ def bottom_simple(x, model_hparams, vocab_size, name, reuse):
     # Add together the embeddings for each tuple position.
     ret = tf.add_n([
         tf.gather(var, x[:, :, :, i] + sum(vocab_size[:i])) *
-        tf.expand_dims(tf.to_float(tf.not_equal(x[:, :, :, i], 0)), -1)
+        tf.expand_dims(tf.cast(tf.not_equal(x[:, :, :, i], 0), tf.float32), -1)
         for i in range(len(vocab_size))
     ])
     if model_hparams.multiply_embedding_mode == 'sqrt_depth':

--- a/magenta/models/shared/events_rnn_graph.py
+++ b/magenta/models/shared/events_rnn_graph.py
@@ -169,10 +169,12 @@ def get_build_graph_fn(mode, config, sequence_example_file_paths=None):
                   :, logits_offsets[i]:logits_offsets[i + 1]], axis=1))
         predictions_flat = tf.stack(predictions, 1)
 
-      correct_predictions = tf.to_float(
-          tf.equal(labels_flat, predictions_flat))
-      event_positions = tf.to_float(tf.not_equal(labels_flat, no_event_label))
-      no_event_positions = tf.to_float(tf.equal(labels_flat, no_event_label))
+      correct_predictions = tf.cast(
+          tf.equal(labels_flat, predictions_flat), tf.float32)
+      event_positions = tf.cast(
+          tf.not_equal(labels_flat, no_event_label), tf.float32)
+      no_event_positions = tf.cast(
+          tf.equal(labels_flat, no_event_label), tf.float32)
 
       # Compute the total number of time steps across all sequences in the
       # batch. For some models this will be different from the number of RNN
@@ -182,7 +184,7 @@ def get_build_graph_fn(mode, config, sequence_example_file_paths=None):
         for labels, length in zip(batch_labels, lengths):
           num_steps += encoder_decoder.labels_to_num_steps(labels[:length])
         return np.float32(num_steps)
-      num_steps = tf.py_func(
+      num_steps = tf.py_function(
           batch_labels_to_num_steps, [labels, lengths], tf.float32)
 
       if mode == 'train':

--- a/magenta/models/svg_vae/svg_decoder.py
+++ b/magenta/models/svg_vae/svg_decoder.py
@@ -281,7 +281,7 @@ class SVGDecoder(t2t_model.T2TModel):
           dtype=tf.float32, time_major=False)
 
   def lstm_cell(self, hparams, train):
-    keep_prob = 1.0 - hparams.rec_dropout * tf.to_float(train)
+    keep_prob = 1.0 - hparams.rec_dropout * tf.cast(train, tf.float32)
 
     recurrent_dropout_cell = contrib_rnn.LayerNormBasicLSTMCell(
         hparams.hidden_size,


### PR DESCRIPTION
## Summary
- replace `tf.to_float` with `tf.cast(..., tf.float32)`
- replace `tf.py_func` with `tf.py_function`
- tweak callers for eager-friendly behaviour

## Testing
- `pip install -e .[test]`
- `pytest --ignore=magenta/models/score2perf` *(fails: 46 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6841d35e49548330aa42b85951c6056f